### PR TITLE
Feature/post  게시글 조회 및 삭제 기능 추가, 서비스레이어 일부 단위 테스트 작성

### DIFF
--- a/src/main/java/com/mincho/herb/common/config/SecurityConfig.java
+++ b/src/main/java/com/mincho/herb/common/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.mincho.herb.common.config;
 import com.mincho.herb.infra.auth.JwtAuthFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -44,15 +45,23 @@ public class SecurityConfig {
                     authorizationManagerRequestMatcherRegistry
                             .requestMatchers("/api/v1/users/register/**").permitAll()
                             .requestMatchers("/api/v1/users/login/**").permitAll()
-//                            .requestMatchers("/api/v1/users/**").hasRole("USER")
-                            .requestMatchers("/api/v1/herbs/**").permitAll()
-                            .requestMatchers("/api/v1/users/**").permitAll()
+                            .requestMatchers(HttpMethod.GET, "/api/v1/community/**").permitAll()
+                            .requestMatchers("/api/v1/users/**").hasAnyRole("USER, ADMIN")
+                            .requestMatchers(HttpMethod.GET, "/api/v1/herbs/**").permitAll()
                             .requestMatchers("/admin/**").hasRole("ADMIN") // 관리자만 허용
                             .anyRequest().permitAll()
                 );
 
         return http.build();
     }
+    /*
+    * http.authorizeHttpRequests(auth -> auth
+    .requestMatchers(HttpMethod.GET, "/api/posts/**").permitAll()  // GET 요청은 모두 허용
+    .requestMatchers(HttpMethod.POST, "/api/posts/**").hasRole("ADMIN")  // POST 요청은 ADMIN만 허용
+    .anyRequest().authenticated()
+);
+    *
+    * */
 
     @Bean
     public UrlBasedCorsConfigurationSource corsConfigurationSource() {

--- a/src/main/java/com/mincho/herb/domain/herb/repository/herbSummary/HerbSummaryJpaRepository.java
+++ b/src/main/java/com/mincho/herb/domain/herb/repository/herbSummary/HerbSummaryJpaRepository.java
@@ -5,8 +5,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import org.springframework.data.domain.Pageable;
-import java.util.List;
-
 public interface HerbSummaryJpaRepository extends JpaRepository<HerbSummaryEntity, Long> {
 
     Page<HerbSummaryEntity> findAll(Pageable pageable);

--- a/src/main/java/com/mincho/herb/domain/post/api/PostServiceController.java
+++ b/src/main/java/com/mincho/herb/domain/post/api/PostServiceController.java
@@ -7,15 +7,17 @@ import com.mincho.herb.common.config.success.SuccessResponse;
 import com.mincho.herb.common.util.CommonUtils;
 import com.mincho.herb.domain.post.application.post.PostService;
 import com.mincho.herb.domain.post.dto.RequestPostDTO;
+import com.mincho.herb.domain.post.dto.ResponsePostDTO;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.Map;
 
 @RestController
@@ -26,10 +28,21 @@ public class PostServiceController {
     private final CommonUtils commonUtils;
     private final PostService postService;
 
+    @GetMapping()
+    @Valid
+    public ResponseEntity<?> getPostsByCategory(
+            @RequestParam("category") @NotEmpty(message = "category 는 필수입니다.") String category,
+            @RequestParam("page") @Min(value = 0, message = "page 는 최소 0 이상이어야 합니다.") Integer page,
+            @RequestParam("size") @Min(value = 5, message = "size 는 최소 5 이상이어야 합니다.") Integer size
+            ){
+
+        List<ResponsePostDTO> posts = postService.getPostsByCategory(page, size, category);
+        return new SuccessResponse<>().getResponse(200, "조회되었습니다.", HttpSuccessType.OK, posts);
+
+    }
+
     @PostMapping()
     public ResponseEntity<Map<String,String>> addPost(@RequestBody RequestPostDTO requestPostDTO, BindingResult result){
-
-
         String email = SecurityContextHolder.getContext().getAuthentication().getName();
 
         if(!commonUtils.emailValidation(email)){
@@ -42,7 +55,32 @@ public class PostServiceController {
         postService.addPost(requestPostDTO, email);
 
         return new SuccessResponse<>().getResponse(201, "추가 되었습니다.", HttpSuccessType.CREATED);
-
     }
 
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Map<String, String>> removePost(@PathVariable("id") Long id){
+        if(id == null){
+            return new ErrorResponse().getResponse(400, "잘못된 요청입니다. 경로 파라미터를 재확인 해주세요.", HttpErrorType.BAD_REQUEST);
+        }
+
+        String email = SecurityContextHolder.getContext().getAuthentication().getName();
+        if(!commonUtils.emailValidation(email)){
+            return new ErrorResponse().getResponse(401, "인증된 유저가 아닙니다.", HttpErrorType.UNAUTHORIZED);
+        }
+
+        postService.removePost(id, email);
+
+        return new SuccessResponse<>().getResponse(200, "정상적으로 삭제처리 되었습니다.", HttpSuccessType.OK);
+    }
+
+    @PatchMapping("/{id}")
+    public ResponseEntity<Map<String, String>> updatePost(
+            @PathVariable("id") Long id,
+            @RequestBody RequestPostDTO requestPostDTO){
+        if(id == null){
+            return new ErrorResponse().getResponse(400, "잘못된 요청입니다. 경로 파라미터를 재확인 해주세요.", HttpErrorType.BAD_REQUEST);
+        }
+
+        return null;
+    }
 }

--- a/src/main/java/com/mincho/herb/domain/post/application/post/PostService.java
+++ b/src/main/java/com/mincho/herb/domain/post/application/post/PostService.java
@@ -1,7 +1,12 @@
 package com.mincho.herb.domain.post.application.post;
 
 import com.mincho.herb.domain.post.dto.RequestPostDTO;
+import com.mincho.herb.domain.post.dto.ResponsePostDTO;
+
+import java.util.List;
 
 public interface PostService {
     void addPost(RequestPostDTO requestPostDTO, String email);
+    void removePost(Long id, String email);
+    List<ResponsePostDTO> getPostsByCategory(int page, int size, String category);
 }

--- a/src/main/java/com/mincho/herb/domain/post/application/post/PostServiceImpl.java
+++ b/src/main/java/com/mincho/herb/domain/post/application/post/PostServiceImpl.java
@@ -1,8 +1,12 @@
 package com.mincho.herb.domain.post.application.post;
 
+import com.mincho.herb.common.config.error.HttpErrorCode;
+import com.mincho.herb.common.exception.CustomHttpException;
+import com.mincho.herb.domain.post.domain.Author;
 import com.mincho.herb.domain.post.domain.Post;
 import com.mincho.herb.domain.post.domain.PostCategory;
 import com.mincho.herb.domain.post.dto.RequestPostDTO;
+import com.mincho.herb.domain.post.dto.ResponsePostDTO;
 import com.mincho.herb.domain.post.entity.PostCategoryEntity;
 import com.mincho.herb.domain.post.entity.PostEntity;
 import com.mincho.herb.domain.post.repository.post.PostRepository;
@@ -11,7 +15,11 @@ import com.mincho.herb.domain.user.entity.UserEntity;
 import com.mincho.herb.domain.user.repository.user.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -47,5 +55,40 @@ public class PostServiceImpl implements PostService{
         
         postRepository.save(unsavedPostEntity);
 
+    }
+
+    @Override
+    public void removePost(Long id, String email) {
+        Long userId = postRepository.findAuthorIdByPostIdAndEmail(id, email);
+        if(userId != null){
+            postRepository.deleteById(id);
+        }
+    }
+
+    @Override
+    public List<ResponsePostDTO> getPostsByCategory(int page, int size, String category) {
+         Pageable pageable = (Pageable) PageRequest.of(page, size);
+         List<PostEntity> postEntities = postRepository.findAllByCategory(category, pageable);
+
+         if(postEntities.isEmpty()){
+             throw new CustomHttpException(HttpErrorCode.RESOURCE_NOT_FOUND, "해당 목록이 존재하지 않습니다.");
+         }
+
+        return postEntities.stream().map(postEntity -> {
+                Author author = Author.builder()
+                                    .id(postEntity.getMember().getId())
+                                    .nickname(postEntity.getMember().getProfile().getNickname())
+                                    .build();
+
+                return ResponsePostDTO.builder()
+                    .id(postEntity.getId())
+                    .category(category)
+                    .title(postEntity.getTitle())
+                    .contents(postEntity.getContents())
+                    .author(author)
+                    .createdAt(postEntity.getCreatedAt())
+                    .updatedAt(postEntity.getUpdatedAt())
+                    .build();
+                }).toList();
     }
 }

--- a/src/main/java/com/mincho/herb/domain/post/domain/Author.java
+++ b/src/main/java/com/mincho/herb/domain/post/domain/Author.java
@@ -1,0 +1,13 @@
+package com.mincho.herb.domain.post.domain;
+
+import lombok.*;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class Author {
+    private Long id;
+    private String nickname;
+}

--- a/src/main/java/com/mincho/herb/domain/post/domain/Post.java
+++ b/src/main/java/com/mincho/herb/domain/post/domain/Post.java
@@ -1,5 +1,6 @@
 package com.mincho.herb.domain.post.domain;
 
+import com.mincho.herb.domain.user.domain.User;
 import lombok.Builder;
 import lombok.Data;
 
@@ -10,7 +11,8 @@ public class Post {
     private Long id;
     private String title;
     private String contents;
-    private PostCategory postCategory;
+    private String category;
+    private User user;
 
     public Post withChangePostContents( String contents){
         return  Post.builder()

--- a/src/main/java/com/mincho/herb/domain/post/dto/ResponsePostDTO.java
+++ b/src/main/java/com/mincho/herb/domain/post/dto/ResponsePostDTO.java
@@ -1,5 +1,6 @@
 package com.mincho.herb.domain.post.dto;
 
+import com.mincho.herb.domain.post.domain.Author;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -12,8 +13,9 @@ import java.time.LocalDateTime;
 public class ResponsePostDTO {
     private Long id;
     private String title;
-    private String content;
+    private String contents;
     private String category;
+    private Author author;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/mincho/herb/domain/post/entity/PostEntity.java
+++ b/src/main/java/com/mincho/herb/domain/post/entity/PostEntity.java
@@ -39,7 +39,6 @@ public class PostEntity extends BaseEntity {
         postEntity.category = postCategoryEntity;
 
         return postEntity;
-
     }
 
     public Post toModel(){
@@ -47,6 +46,8 @@ public class PostEntity extends BaseEntity {
                 .id(this.id)
                 .title(this.title)
                 .contents(this.contents)
+                .category(null)
+                .user(this.member.toModel())
                 .build();
     }
 }

--- a/src/main/java/com/mincho/herb/domain/post/repository/post/PostJpaRepository.java
+++ b/src/main/java/com/mincho/herb/domain/post/repository/post/PostJpaRepository.java
@@ -1,8 +1,19 @@
 package com.mincho.herb.domain.post.repository.post;
 
 import com.mincho.herb.domain.post.entity.PostEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
 
 public interface PostJpaRepository extends JpaRepository<PostEntity, Long> {
+        @Query("SELECT p FROM PostEntity p JOIN FETCH p.member WHERE p.category.category = :category")
+        Page<PostEntity> findAllByCategory(@Param("category") String category, Pageable pageable);
 
+        @Query("SELECT p.member.id FROM PostEntity p WHERE p.id = :postId AND p.member.email = :email")
+        Optional<Long> findAuthorIdByPostIdAndEmail(@Param("postId") Long postId, @Param("email") String email);
 }

--- a/src/main/java/com/mincho/herb/domain/post/repository/post/PostRepository.java
+++ b/src/main/java/com/mincho/herb/domain/post/repository/post/PostRepository.java
@@ -2,6 +2,7 @@ package com.mincho.herb.domain.post.repository.post;
 
 import com.mincho.herb.domain.post.entity.PostEntity;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -9,5 +10,7 @@ public interface PostRepository {
 
     void save(PostEntity postEntity);
     PostEntity findById(Long postId);
-    List<PostEntity> findAll(Pageable pageable);
+    List<PostEntity> findAllByCategory(String category, Pageable pageable);
+    Long findAuthorIdByPostIdAndEmail(Long postId, String email);
+    void deleteById(Long id);
 }

--- a/src/main/java/com/mincho/herb/domain/post/repository/post/PostRepositoryImpl.java
+++ b/src/main/java/com/mincho/herb/domain/post/repository/post/PostRepositoryImpl.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
@@ -25,7 +26,19 @@ public class PostRepositoryImpl implements PostRepository{
     }
 
     @Override
-    public List<PostEntity> findAll(Pageable pageable) {
-        return postJpaRepository.findAll(pageable).stream().toList();
+    public List<PostEntity> findAllByCategory(String category, Pageable pageable) {
+        return postJpaRepository.findAllByCategory(category, pageable).stream().toList();
+    }
+
+    // 해당 포스트를 작성한 유저 조회
+    @Override
+    public Long findAuthorIdByPostIdAndEmail(Long postId, String email) {
+        return postJpaRepository.findAuthorIdByPostIdAndEmail(postId, email)
+                .orElseThrow(()-> new CustomHttpException(HttpErrorCode.FORBIDDEN_ACCESS, "요청 권한이 있는 유저가 아닙니다."));
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        postJpaRepository.deleteById(id);
     }
 }

--- a/src/main/java/com/mincho/herb/domain/post/repository/postCategory/PostCategoryRepository.java
+++ b/src/main/java/com/mincho/herb/domain/post/repository/postCategory/PostCategoryRepository.java
@@ -6,5 +6,6 @@ public interface PostCategoryRepository {
 
     PostCategoryEntity save(PostCategoryEntity postCategoryEntity);
     PostCategoryEntity findByCategory(String category);
+    void deleteById(Long id);
     boolean existsCategory(String category);
 }

--- a/src/main/java/com/mincho/herb/domain/post/repository/postCategory/PostCategoryRepositoryImpl.java
+++ b/src/main/java/com/mincho/herb/domain/post/repository/postCategory/PostCategoryRepositoryImpl.java
@@ -20,6 +20,11 @@ public class PostCategoryRepositoryImpl implements PostCategoryRepository{
     }
 
     @Override
+    public void deleteById(Long id) {
+        postCategoryJpaRepository.deleteById(id);
+    }
+
+    @Override
     public boolean existsCategory(String category) {
         return postCategoryJpaRepository.existsByCategory(category);
     }

--- a/src/main/java/com/mincho/herb/domain/user/entity/UserEntity.java
+++ b/src/main/java/com/mincho/herb/domain/user/entity/UserEntity.java
@@ -3,7 +3,9 @@ package com.mincho.herb.domain.user.entity;
 import com.mincho.herb.common.base.BaseEntity;
 import com.mincho.herb.domain.user.domain.User;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -13,6 +15,8 @@ import java.time.LocalDateTime;
 @Table(name = "member")
 @Getter
 @Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class UserEntity extends BaseEntity {
 
     @Id
@@ -30,12 +34,6 @@ public class UserEntity extends BaseEntity {
 
     @OneToOne(mappedBy = "member")
     private ProfileEntity profile;
-
-    @CreatedDate
-    private LocalDateTime createdAt;
-
-    @LastModifiedDate
-    private LocalDateTime updatedAt;
 
 
     public static UserEntity toEntity(User userDomain){

--- a/src/test/java/com/mincho/herb/domain/post/application/PostServiceTest.java
+++ b/src/test/java/com/mincho/herb/domain/post/application/PostServiceTest.java
@@ -1,22 +1,31 @@
 package com.mincho.herb.domain.post.application;
 
+import com.mincho.herb.common.config.error.HttpErrorCode;
+import com.mincho.herb.common.exception.CustomHttpException;
 import com.mincho.herb.domain.post.application.post.PostServiceImpl;
 import com.mincho.herb.domain.post.dto.RequestPostDTO;
+import com.mincho.herb.domain.post.dto.ResponsePostDTO;
 import com.mincho.herb.domain.post.entity.PostCategoryEntity;
 import com.mincho.herb.domain.post.entity.PostEntity;
 import com.mincho.herb.domain.post.repository.post.PostRepository;
 import com.mincho.herb.domain.post.repository.postCategory.PostCategoryRepository;
 import com.mincho.herb.domain.user.entity.UserEntity;
 import com.mincho.herb.domain.user.repository.user.UserRepository;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 
-class PostServiceImplTest {
+class PostServiceTest {
 
     @Mock
     private PostRepository postRepository;
@@ -44,8 +53,9 @@ class PostServiceImplTest {
         userEntity.setEmail(email);
     }
 
+    // 포스트 추가
     @Test
-    void addPost_whenCategoryExists() {
+    void addPost_WhenCategoryExists() {
         // given
         PostCategoryEntity existingPostCategoryEntity = new PostCategoryEntity();
         existingPostCategoryEntity.setCategory("정보");
@@ -62,7 +72,7 @@ class PostServiceImplTest {
     }
 
     @Test
-    void addPost_whenCategoryNotExists() {
+    void addPost_WhenCategoryNotExists() {
         // given
         when(userRepository.findByEmail(email)).thenReturn(userEntity);
         when(postCategoryRepository.findByCategory(requestPostDTO.getCategory())).thenReturn(null);
@@ -74,5 +84,78 @@ class PostServiceImplTest {
         verify(postCategoryRepository, times(1)).findByCategory(requestPostDTO.getCategory());
         verify(postCategoryRepository, times(1)).save(any(PostCategoryEntity.class));
         verify(postRepository, times(1)).save(any(PostEntity.class));
+    }
+
+    @Test
+    void getPostsByCategory_WhenPostsExist_ShouldReturnPostDTOs() {
+        // given
+        String category = "Health";
+        int page = 0;
+        int size = 5;
+
+        PostEntity postEntity1 = new PostEntity(1L, "Post 1", "Content 1", null, null);
+        PostEntity postEntity2 = new PostEntity(2L, "Post 2", "Content 2", null, null);
+        List<PostEntity> postEntities = List.of(postEntity1, postEntity2);
+
+        Pageable pageable = PageRequest.of(page, size);
+        when(postRepository.findAllByCategory(category, pageable)).thenReturn(postEntities);
+
+        // when
+        List<ResponsePostDTO> response = postService.getPostsByCategory(page, size, category);
+
+        // then
+        assertEquals(2, response.size());
+        assertEquals("Post 1", response.get(0).getTitle());
+        assertEquals("Post 2", response.get(1).getTitle());
+    }
+
+    @Test
+    void getPostsByCategory_WhenNoPostsExist_ShouldThrowException() {
+        // given
+        String category = "Health";
+        int page = 0;
+        int size = 5;
+
+        Pageable pageable = PageRequest.of(page, size);
+        when(postRepository.findAllByCategory(category, pageable)).thenReturn(List.of());
+
+        // when & then
+        CustomHttpException exception = Assertions.assertThrows(CustomHttpException.class, () -> {
+            postService.getPostsByCategory(page, size, category);
+        });
+
+        assertEquals(HttpErrorCode.RESOURCE_NOT_FOUND, exception.getHttpErrorCode());
+        assertEquals("해당 목록이 존재하지 않습니다.", exception.getMessage());
+    }
+
+    // 게시글 삭제
+    @Test
+    void removePost_Success() {
+        // given
+        Long postId = 1L;
+        String email = "test@example.com";
+
+        when(postRepository.findAuthorIdByPostIdAndEmail(postId, email)).thenReturn(42L);
+
+        // when
+        postService.removePost(postId, email);
+
+        // then
+        verify(postRepository, times(1)).deleteById(postId);
+    }
+
+    @Test
+    void removePost_NoPermission() {
+        // given
+        Long postId = 1L;
+        String email = "unauthorized@example.com";
+
+        when(postRepository.findAuthorIdByPostIdAndEmail(postId, email)).thenReturn(null);
+
+        // when
+        postService.removePost(postId, email);
+
+        // then
+        verify(postRepository, never()).deleteById(postId);
     }
 }


### PR DESCRIPTION
## 변경된 것
- 게시글 조회 기능 추가(카테고리별)
- 게시글 삭제 기능 추가 및 서비스 레이어 단위테스트
  - 주요 포인트: 게시글을 삭제한 유저와 작성한 유저가 다르면 403 으로 접근 불가능 토록 처리