### PR TITLE
Feature/comment 댓글 논리적 삭제 및 수정 기능 추가, 서비스 레이어 일부 단위 테스트 추가

### DIFF
--- a/src/main/java/com/mincho/herb/domain/comment/api/CommentController.java
+++ b/src/main/java/com/mincho/herb/domain/comment/api/CommentController.java
@@ -8,30 +8,34 @@ import com.mincho.herb.common.config.success.SuccessResponse;
 import com.mincho.herb.common.exception.CustomHttpException;
 import com.mincho.herb.common.util.CommonUtils;
 import com.mincho.herb.domain.comment.application.CommentService;
-import com.mincho.herb.domain.comment.dto.RequestCommentDTO;
+import com.mincho.herb.domain.comment.dto.RequestCommentCreateDTO;
+import com.mincho.herb.domain.comment.dto.RequestCommentUpdateDTO;
+import com.mincho.herb.domain.comment.dto.ResponseCommentDTO;
 import jakarta.annotation.Nullable;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
+@Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/community/posts/{postId}/comments/{parentCommentId}")
+@RequestMapping("/api/v1/community")
 public class CommentController {
 
     private final CommonUtils commonUtils;
     private final CommentService commentService;
 
-    @PostMapping()
+    @PostMapping("/posts/{postId}/comments/{commentId}")
     public ResponseEntity<?> addComment(@PathVariable @NotNull(message ="postId 는 필수입니다.") Long postId,
-                                        @PathVariable @Nullable Long parentCommentId,
-                                        @Valid @RequestBody RequestCommentDTO requestCommentDTO,
+                                        @PathVariable @Nullable Long commentId,
+                                        @Valid @RequestBody RequestCommentCreateDTO requestCommentCreateDTO,
                                         BindingResult result){
         if(result.hasErrors()){
             return new ErrorResponse().getResponse(400, commonUtils.extractErrorMessage(result), HttpErrorType.BAD_REQUEST);
@@ -42,10 +46,33 @@ public class CommentController {
             throw new CustomHttpException(HttpErrorCode.FORBIDDEN_ACCESS,"요청 권한이 없습니다.");
         }
 
-        requestCommentDTO.setParentCommentId(parentCommentId);
-        requestCommentDTO.setPostId(postId);
+        requestCommentCreateDTO.setParentCommentId(commentId);
+        requestCommentCreateDTO.setPostId(postId);
 
-        commentService.addComment(requestCommentDTO, email);
+        commentService.addComment(requestCommentCreateDTO, email);
         return new SuccessResponse<>().getResponse(201, "성공적으로 댓글이 추가되었습니다.", HttpSuccessType.CREATED);
+    }
+
+    @GetMapping("/posts/{postId}/comments")
+    public ResponseEntity<?> getComments(@PathVariable Long postId){
+        log.info("postId: {}", postId);
+        List<ResponseCommentDTO> list = commentService.getCommentsByPostId(postId);
+        return new SuccessResponse<>().getResponse(200, "성공적으로 댓글을 조회하였습니다.", HttpSuccessType.OK, list );
+    }
+
+    @PatchMapping("/comments/{commentId}")
+    public ResponseEntity<?> patchComment(
+            @PathVariable @Nullable Long commentId,
+            @RequestBody RequestCommentUpdateDTO requestCommentUpdateDTO
+            ){
+        String email = SecurityContextHolder.getContext().getAuthentication().getName();
+        if(!email.contains("@")){
+            throw new CustomHttpException(HttpErrorCode.FORBIDDEN_ACCESS,"요청 권한이 없습니다.");
+        }
+
+        requestCommentUpdateDTO.setId(commentId);
+        commentService.updateComment(requestCommentUpdateDTO);
+
+        return new SuccessResponse<>().getResponse(200, "성공적으로 처리되었습니다.", HttpSuccessType.OK);
     }
 }

--- a/src/main/java/com/mincho/herb/domain/comment/application/CommentService.java
+++ b/src/main/java/com/mincho/herb/domain/comment/application/CommentService.java
@@ -1,8 +1,14 @@
 package com.mincho.herb.domain.comment.application;
 
-import com.mincho.herb.domain.comment.dto.RequestCommentDTO;
+import com.mincho.herb.domain.comment.dto.RequestCommentCreateDTO;
+import com.mincho.herb.domain.comment.dto.RequestCommentUpdateDTO;
+import com.mincho.herb.domain.comment.dto.ResponseCommentDTO;
+
+import java.util.List;
 
 public interface CommentService {
 
-    void addComment(RequestCommentDTO requestCommentDTO, String email);
+    void addComment(RequestCommentCreateDTO requestCommentCreateDTO, String email);
+    List<ResponseCommentDTO> getCommentsByPostId(Long postId);
+    void updateComment(RequestCommentUpdateDTO requestCommentUpdateDTO);
 }

--- a/src/main/java/com/mincho/herb/domain/comment/application/CommentServiceImpl.java
+++ b/src/main/java/com/mincho/herb/domain/comment/application/CommentServiceImpl.java
@@ -1,6 +1,10 @@
 package com.mincho.herb.domain.comment.application;
 
-import com.mincho.herb.domain.comment.dto.RequestCommentDTO;
+import com.mincho.herb.common.config.error.HttpErrorCode;
+import com.mincho.herb.common.exception.CustomHttpException;
+import com.mincho.herb.domain.comment.dto.RequestCommentCreateDTO;
+import com.mincho.herb.domain.comment.dto.RequestCommentUpdateDTO;
+import com.mincho.herb.domain.comment.dto.ResponseCommentDTO;
 import com.mincho.herb.domain.comment.entity.CommentEntity;
 import com.mincho.herb.domain.comment.repository.CommentRepository;
 import com.mincho.herb.domain.post.entity.PostEntity;
@@ -11,6 +15,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 
 @Slf4j
 @Service
@@ -20,16 +26,17 @@ public class CommentServiceImpl implements CommentService{
     private final CommentRepository commentRepository;
     private final UserRepository userRepository;
     private final PostRepository postRepository;
+
     @Override
-    public void addComment(RequestCommentDTO requestCommentDTO, String email) {
+    public void addComment(RequestCommentCreateDTO requestCommentCreateDTO, String email) {
 
         MemberEntity memberEntity = userRepository.findByEmail(email);
-        PostEntity postEntity = postRepository.findById(requestCommentDTO.getPostId());
+        PostEntity postEntity = postRepository.findById(requestCommentCreateDTO.getPostId());
 
 
         CommentEntity parentCommentEntity = null;
-        if(requestCommentDTO.getParentCommentId() != null){
-            parentCommentEntity = commentRepository.findById(requestCommentDTO.getParentCommentId());
+        if(requestCommentCreateDTO.getParentCommentId() != null){
+            parentCommentEntity = commentRepository.findById(requestCommentCreateDTO.getParentCommentId());
         }
 
         // 부모 도메인이 존재하지 않을 때 까지 level 증가
@@ -44,7 +51,7 @@ public class CommentServiceImpl implements CommentService{
 
         CommentEntity unsavedCommentEntity = CommentEntity.builder()
                                                 .level(depth)
-                                                .contents(requestCommentDTO.getContents())
+                                                .contents(requestCommentCreateDTO.getContents())
                                                 .deleted(false)
                                                 .member(memberEntity)
                                                 .post(postEntity)
@@ -52,5 +59,50 @@ public class CommentServiceImpl implements CommentService{
                                                 .build();
 
         commentRepository.save(unsavedCommentEntity);
+    }
+
+    @Override
+    public List<ResponseCommentDTO> getCommentsByPostId(Long postId) {
+        // 부모 댓글과 자식 댓글을 모두 가져오는 페치 조인 쿼리 실행
+        List<CommentEntity> parentCommentEntities = commentRepository.findByPostId(postId);
+
+
+        return parentCommentEntities.stream().map((commentEntity)-> {
+                 List<ResponseCommentDTO> replies =  commentRepository.findByParentComment(commentEntity).stream().map(replyEntity -> {
+                     return ResponseCommentDTO.builder()
+                             .id(replyEntity.getId())
+                             .contents(replyEntity.getContents())
+                             .nickname(replyEntity.getMember().getProfile().getNickname())
+                             .isDeleted(replyEntity.getDeleted())
+                             .level(replyEntity.getLevel())
+                             .build();
+                 }).toList();
+
+
+                return ResponseCommentDTO.builder()
+                        .id(commentEntity.getId())
+                        .contents(commentEntity.getContents())
+                        .nickname(commentEntity.getMember().getProfile().getNickname())
+                        .isDeleted(commentEntity.getDeleted())
+                        .level(commentEntity.getLevel())
+                        .replies(replies)
+                        .build();
+                }
+
+                ).toList();
+    }
+    @Override
+    public void updateComment(RequestCommentUpdateDTO requestCommentUpdateDTO) {
+      Long commentId  = requestCommentUpdateDTO.getId();
+      CommentEntity commentEntity = commentRepository.findById(commentId);
+
+      if(commentEntity == null){
+          throw new CustomHttpException(HttpErrorCode.RESOURCE_NOT_FOUND, "이미 삭제된 댓글입니다.");
+      }
+
+      commentEntity.setDeleted(requestCommentUpdateDTO.getIsDeleted());
+      commentEntity.setContents(requestCommentUpdateDTO.getContents());
+
+      commentRepository.save(commentEntity);
     }
 }

--- a/src/main/java/com/mincho/herb/domain/comment/dto/RequestCommentCreateDTO.java
+++ b/src/main/java/com/mincho/herb/domain/comment/dto/RequestCommentCreateDTO.java
@@ -1,6 +1,5 @@
 package com.mincho.herb.domain.comment.dto;
 
-import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
 import lombok.*;
 
@@ -9,11 +8,11 @@ import lombok.*;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-public class RequestCommentDTO {
+public class RequestCommentCreateDTO {
 
     @Size(min = 2, max = 5000, message = "텍스트는 최소 2자 이상 5000자 이하로 작성되어야 합니다.")
     private String contents;
-    private String email;
+    private Boolean isDeleted;
     private Long postId;
     private Long parentCommentId;
 }

--- a/src/main/java/com/mincho/herb/domain/comment/dto/RequestCommentUpdateDTO.java
+++ b/src/main/java/com/mincho/herb/domain/comment/dto/RequestCommentUpdateDTO.java
@@ -1,0 +1,18 @@
+package com.mincho.herb.domain.comment.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class RequestCommentUpdateDTO {
+
+    private Long id;
+    private String contents;
+    private Boolean isDeleted;
+
+}

--- a/src/main/java/com/mincho/herb/domain/comment/dto/ResponseCommentDTO.java
+++ b/src/main/java/com/mincho/herb/domain/comment/dto/ResponseCommentDTO.java
@@ -1,0 +1,20 @@
+package com.mincho.herb.domain.comment.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ResponseCommentDTO {
+    private Long id;
+    private String contents;
+    private String nickname;
+    private Boolean isDeleted;
+    private Long parentCommentId;
+    private Long level;
+    private List<ResponseCommentDTO> replies;
+}

--- a/src/main/java/com/mincho/herb/domain/comment/entity/CommentEntity.java
+++ b/src/main/java/com/mincho/herb/domain/comment/entity/CommentEntity.java
@@ -5,18 +5,17 @@ import com.mincho.herb.domain.comment.domain.Comment;
 import com.mincho.herb.domain.post.entity.PostEntity;
 import com.mincho.herb.domain.user.entity.MemberEntity;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 
-@Entity
-@Table(name = "Comment")
+@Entity(name = "Comments")
+@Table(name = "comments")
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
+@Setter
 @Builder
+@ToString
 public class CommentEntity extends BaseEntity {
 
     @Id

--- a/src/main/java/com/mincho/herb/domain/comment/repository/CommentJpaRepository.java
+++ b/src/main/java/com/mincho/herb/domain/comment/repository/CommentJpaRepository.java
@@ -2,6 +2,26 @@ package com.mincho.herb.domain.comment.repository;
 
 import com.mincho.herb.domain.comment.entity.CommentEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface CommentJpaRepository  extends JpaRepository<CommentEntity, Long> {
+
+
+    @Query("SELECT c FROM Comments c " +
+            "LEFT JOIN FETCH c.member m " +
+            "LEFT JOIN FETCH m.profile " +
+            "WHERE c.post.id = :postId AND c.parentComment.id IS NULL")
+    List<CommentEntity> findByPostId(@Param("postId") Long postId);
+
+    @Query("SELECT c FROM Comments c " +
+            "LEFT JOIN FETCH c.member m " +
+            "LEFT JOIN FETCH m.profile " +
+            "WHERE c.parentComment = :parentComment")
+    List<CommentEntity> findByParentComment(@Param("parentComment") CommentEntity parentComment);
+
+
+
 }

--- a/src/main/java/com/mincho/herb/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/mincho/herb/domain/comment/repository/CommentRepository.java
@@ -3,9 +3,16 @@ package com.mincho.herb.domain.comment.repository;
 
 import com.mincho.herb.domain.comment.entity.CommentEntity;
 
+import java.util.List;
+
 public interface CommentRepository {
 
     void save(CommentEntity commentEntity);
     CommentEntity findById(Long parentCommentId);
+    List<CommentEntity> findByPostId(Long postId);
+    List<CommentEntity> findByParentComment(CommentEntity parentComment);
+
+    void updateComment(CommentEntity commentEntity);
+
 
 }

--- a/src/main/java/com/mincho/herb/domain/comment/repository/CommentRepositoryImpl.java
+++ b/src/main/java/com/mincho/herb/domain/comment/repository/CommentRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.mincho.herb.domain.comment.entity.CommentEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -24,5 +25,21 @@ public class CommentRepositoryImpl implements CommentRepository{
             return optional.get();
         }
         return null;
+    }
+
+    @Override
+    public List<CommentEntity> findByPostId(Long postId) {
+        return commentJpaRepository.findByPostId(postId);
+
+    }
+
+    @Override
+    public List<CommentEntity> findByParentComment(CommentEntity parentComment) {
+        return commentJpaRepository.findByParentComment(parentComment);
+    }
+
+    @Override
+    public void updateComment(CommentEntity commentEntity) {
+        commentJpaRepository.save(commentEntity);
     }
 }

--- a/src/main/java/com/mincho/herb/domain/user/entity/ProfileEntity.java
+++ b/src/main/java/com/mincho/herb/domain/user/entity/ProfileEntity.java
@@ -4,10 +4,12 @@ package com.mincho.herb.domain.user.entity;
 import com.mincho.herb.domain.user.domain.Profile;
 import jakarta.persistence.*;
 import lombok.Data;
+import lombok.ToString;
 
 @Entity(name = "Profile")
 @Table(name = "profile")
 @Data
+@ToString
 public class ProfileEntity {
 
 


### PR DESCRIPTION
## 추가된 사항
- 커뮤니티 댓글 논리적 삭제 기능 추가
  -  실제 데이터베이스에서 댓글을 삭제처리하는 것이 아니므로 댓글 수정 기능과 동일한 메소드와 경로로 처리함