### PR TITLE
Feature/qna: QnA 이미지 업로드/조회/수정/삭제 기능 구현, answer 답변 등록 기능 구현 및  유효성 검증 로직 추가

### DIFF
--- a/src/main/java/com/mincho/herb/domain/qna/api/AnswerController.java
+++ b/src/main/java/com/mincho/herb/domain/qna/api/AnswerController.java
@@ -1,0 +1,4 @@
+package com.mincho.herb.domain.qna.api;
+
+public class AnswerController {
+}

--- a/src/main/java/com/mincho/herb/domain/qna/api/QnaImageController.java
+++ b/src/main/java/com/mincho/herb/domain/qna/api/QnaImageController.java
@@ -1,0 +1,4 @@
+package com.mincho.herb.domain.qna.api;
+
+public class QnaImageController {
+}

--- a/src/main/java/com/mincho/herb/domain/qna/api/QnaReactionController.java
+++ b/src/main/java/com/mincho/herb/domain/qna/api/QnaReactionController.java
@@ -1,0 +1,4 @@
+package com.mincho.herb.domain.qna.api;
+
+public class QnaReactionController {
+}

--- a/src/main/java/com/mincho/herb/domain/qna/application/answer/AnswerService.java
+++ b/src/main/java/com/mincho/herb/domain/qna/application/answer/AnswerService.java
@@ -1,0 +1,7 @@
+package com.mincho.herb.domain.qna.application;
+
+import com.mincho.herb.domain.qna.dto.AnswerRequestDTO;
+
+public interface AnswerService {
+    void create(Long qnaId, AnswerRequestDTO requestDTO);
+}

--- a/src/main/java/com/mincho/herb/domain/qna/application/answer/AnswerServiceImpl.java
+++ b/src/main/java/com/mincho/herb/domain/qna/application/answer/AnswerServiceImpl.java
@@ -1,0 +1,51 @@
+package com.mincho.herb.domain.qna.application;
+
+import com.mincho.herb.domain.qna.dto.AnswerRequestDTO;
+import com.mincho.herb.domain.qna.entity.AnswerEntity;
+import com.mincho.herb.domain.qna.entity.QnaEntity;
+import com.mincho.herb.domain.qna.repository.answer.AnswerRepository;
+import com.mincho.herb.domain.qna.repository.qna.QnaRepository;
+import com.mincho.herb.domain.user.application.user.UserService;
+import com.mincho.herb.domain.user.entity.MemberEntity;
+import com.mincho.herb.global.config.error.HttpErrorCode;
+import com.mincho.herb.global.exception.CustomHttpException;
+import com.mincho.herb.global.util.CommonUtils;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AnswerServiceImpl implements AnswerService {
+    private final QnaRepository qnaRepository;
+    private final AnswerRepository answerRepository;
+    private final UserService userService;
+    private final CommonUtils commonUtils;
+
+    @Override
+    public void create(Long qnaId, AnswerRequestDTO requestDTO) {
+        String email =throwAuthExceptionOrReturnEmail();
+        QnaEntity qna = qnaRepository.findById(qnaId);
+        MemberEntity writer = userService.getUserByEmail(email);
+
+        AnswerEntity entity = AnswerEntity.builder()
+                .qna(qna)
+                .writer(writer)
+                .content(requestDTO.getContent())
+                .isAdopted(false)
+                .build();
+
+        answerRepository.save(entity);
+    }
+
+    // 유저 체크(성공 시 유저 이메일 반환)
+    private String throwAuthExceptionOrReturnEmail(){
+        String email = commonUtils.userCheck();
+        if(email == null){
+            throw new CustomHttpException(HttpErrorCode.UNAUTHORIZED_REQUEST,"로그인 후 이용 가능합니다.");
+        }
+        return email;
+    }
+}

--- a/src/main/java/com/mincho/herb/domain/qna/application/answerImage/AnswerImageService.java
+++ b/src/main/java/com/mincho/herb/domain/qna/application/answerImage/AnswerImageService.java
@@ -1,0 +1,12 @@
+package com.mincho.herb.domain.qna.application.answer;
+
+import com.mincho.herb.domain.qna.application.common.ImageService;
+import com.mincho.herb.domain.qna.entity.AnswerEntity;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+public interface AnswerImageService extends ImageService {
+    void imageUpload(List<MultipartFile> images, AnswerEntity answerEntity);
+    void imageDelete(List<String> images, AnswerEntity answerEntity);
+}

--- a/src/main/java/com/mincho/herb/domain/qna/application/answerImage/AnswerImageServiceImpl.java
+++ b/src/main/java/com/mincho/herb/domain/qna/application/answerImage/AnswerImageServiceImpl.java
@@ -1,0 +1,149 @@
+package com.mincho.herb.domain.qna.application.answer;
+
+
+import com.mincho.herb.domain.qna.entity.AnswerEntity;
+import com.mincho.herb.domain.qna.entity.AnswerImageEntity;
+import com.mincho.herb.domain.qna.repository.answer.AnswerRepository;
+import com.mincho.herb.domain.qna.repository.answerImage.AnswerImageRepository;
+import com.mincho.herb.global.config.error.HttpErrorCode;
+import com.mincho.herb.global.exception.CustomHttpException;
+import com.mincho.herb.global.util.CommonUtils;
+import com.mincho.herb.infra.auth.S3Service;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AnswerImageServiceImpl implements  AnswerImageService {
+    private final S3Service s3Service;
+    private final AnswerRepository answerRepository;
+    private final AnswerImageRepository answerImageRepository;
+    private final CommonUtils commonUtils;
+    private static final int MAX_IMAGE_COUNT = 3;
+    private static final long MAX_FILE_SIZE = 1024 * 1024; // 1MB
+    private static final List<String> ALLOWED_EXTENSIONS = List.of(
+            "jpg", "jpeg", "png", "webp", "svg"
+    );
+
+    // 이미지 조회
+    @Override
+    public List<String> getImages(Long answerId) {
+        return answerImageRepository.findAllImageUrlsByAnswerId(answerId);
+    }
+
+    // 이미지 업로드
+    @Override
+    public void imageUpload(List<MultipartFile> images, AnswerEntity answerEntity) {
+
+        throwValidImageException(images);
+
+        // 이미지 업로드(S3, DB)
+        images.forEach(image -> {
+            answerImageRepository.save(
+                    AnswerImageEntity.builder()
+                            .imageUrl(s3Service.upload(image, "answer/" + answerEntity.getId()))
+                            .answer(answerEntity)
+                            .build()
+            );
+        });
+    }
+
+
+    // 이미지 업로드(API 전용)
+    @Override
+    @Transactional
+    public void imageUpload(List<MultipartFile> images, Long answerId) {
+        throwValidImageException(images);
+
+
+        AnswerEntity answerEntity = answerRepository.findById(answerId);
+
+        // 이미지 업로드(S3, DB)
+        images.forEach(image -> {
+            answerImageRepository.save(
+                    AnswerImageEntity.builder()
+                            .imageUrl(s3Service.upload(image, "qna/" + answerEntity.getId()))
+                            .answer(answerEntity)
+                            .build()
+            );
+        });
+    }
+
+    // 이미지 수정
+    @Override
+    @Transactional
+    public void imageUpdate(List<String> newImageUrls, Long id) {
+        throwAuthExceptionOrReturnEmail(); // 예외 처리
+
+        List<String> prevImageUrls = answerImageRepository.findAllImageUrlsByAnswerId(id); // 이전 이미지
+
+        // ex [ 1, 2, 3, 4] - [3, 4] = [1, 2] -> prevImageUrls 에는 제거해야 할 이미지만 남는다.
+        prevImageUrls.removeAll(newImageUrls);
+
+        // 빈 게 아니라면 DB, S3 버킷에 반영
+        if (!prevImageUrls.isEmpty()) {
+            answerImageRepository.deleteByImageUrlIn(prevImageUrls);
+
+            prevImageUrls.forEach(targetUrl-> {
+                String key = s3Service.extractKeyFromUrl(targetUrl);
+                s3Service.deleteKey(key);
+            });
+        }
+    }
+
+
+    // 이미지 삭제
+    @Override
+    @Transactional
+    public void imageDelete(List<String> imageUrls, AnswerEntity answerEntity) {
+        for(String imageUrl : imageUrls){
+            String key = s3Service.extractKeyFromUrl(imageUrl);
+            s3Service.deleteKey(key);
+        }
+
+        answerImageRepository.deleteByAnswerId(answerEntity.getId());
+
+    }
+
+
+    // 유저 체크(성공 시 유저 이메일 반환)
+    private String throwAuthExceptionOrReturnEmail(){
+        String email = commonUtils.userCheck();
+        if(email == null){
+            throw new CustomHttpException(HttpErrorCode.UNAUTHORIZED_REQUEST,"로그인 후 이용 가능합니다.");
+        }
+        return email;
+    }
+
+    // 이미지 유효성 체크
+    private void throwValidImageException(List<MultipartFile> images){
+        if(!images.isEmpty()){
+            if (images.size() > MAX_IMAGE_COUNT) {
+                throw new CustomHttpException(HttpErrorCode.BAD_REQUEST, "이미지는 최대 3개까지만 업로드할 수 있습니다.");
+            }
+
+
+            for (MultipartFile image : images) {
+                if (image.isEmpty()) {
+                    throw new CustomHttpException(HttpErrorCode.BAD_REQUEST,"빈 파일은 업로드할 수 없습니다.");
+                }
+
+                if (image.getSize() > MAX_FILE_SIZE) {
+                    throw new CustomHttpException(HttpErrorCode.BAD_REQUEST,"각 이미지 파일 크기는 1MB 이하여야 합니다.");
+                }
+
+                log.info("image type:{}", image.getContentType());
+                if (!ALLOWED_EXTENSIONS.contains(Objects.requireNonNull(image.getContentType()).split("/")[1])) {
+                    throw new CustomHttpException(HttpErrorCode.BAD_REQUEST,"지원하지 않는 이미지 형식입니다. (JPEG, PNG, webp, svg 만 허용)");
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/mincho/herb/domain/qna/application/common/ImageService.java
+++ b/src/main/java/com/mincho/herb/domain/qna/application/common/ImageService.java
@@ -1,0 +1,4 @@
+package com.mincho.herb.domain.qna.application.common;
+
+public interface ImageService {
+}

--- a/src/main/java/com/mincho/herb/domain/qna/application/qna/QnaReactionService.java
+++ b/src/main/java/com/mincho/herb/domain/qna/application/qna/QnaReactionService.java
@@ -1,0 +1,5 @@
+package com.mincho.herb.domain.qna.application;
+
+public interface QnaReactionService {
+
+}

--- a/src/main/java/com/mincho/herb/domain/qna/application/qna/QnaService.java
+++ b/src/main/java/com/mincho/herb/domain/qna/application/qna/QnaService.java
@@ -1,0 +1,19 @@
+package com.mincho.herb.domain.qna.application;
+
+import com.mincho.herb.domain.qna.dto.QnaDTO;
+import com.mincho.herb.domain.qna.dto.QnaRequestDTO;
+import com.mincho.herb.domain.qna.dto.QnaResponseDTO;
+import com.mincho.herb.domain.qna.dto.QnaSearchConditionDTO;
+import com.mincho.herb.domain.qna.entity.QnaEntity;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+public interface QnaService {
+    QnaEntity create(QnaRequestDTO dto, List<MultipartFile> files);
+    QnaDTO getById(Long id);
+    QnaResponseDTO getAllBySearchCondition(QnaSearchConditionDTO conditionDTO, Pageable pageable);
+    void update(Long id, QnaRequestDTO dto);
+    void delete(Long id);
+}

--- a/src/main/java/com/mincho/herb/domain/qna/application/qna/QnaServiceImpl.java
+++ b/src/main/java/com/mincho/herb/domain/qna/application/qna/QnaServiceImpl.java
@@ -1,0 +1,139 @@
+package com.mincho.herb.domain.qna.application;
+
+import com.mincho.herb.domain.qna.domain.Qna;
+import com.mincho.herb.domain.qna.dto.QnaDTO;
+import com.mincho.herb.domain.qna.dto.QnaRequestDTO;
+import com.mincho.herb.domain.qna.dto.QnaResponseDTO;
+import com.mincho.herb.domain.qna.dto.QnaSearchConditionDTO;
+import com.mincho.herb.domain.qna.entity.AnswerEntity;
+import com.mincho.herb.domain.qna.entity.QnaEntity;
+import com.mincho.herb.domain.qna.repository.qna.QnaRepository;
+import com.mincho.herb.domain.user.application.user.UserService;
+import com.mincho.herb.domain.user.entity.MemberEntity;
+import com.mincho.herb.global.config.error.HttpErrorCode;
+import com.mincho.herb.global.exception.CustomHttpException;
+import com.mincho.herb.global.util.CommonUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class QnaServiceImpl implements QnaService {
+
+    private final QnaRepository qnaRepository;
+    private final UserService userService;
+    private final QnaImageService qnaImageService;
+    private final CommonUtils commonUtils;
+
+    // 질문 생성
+    @Override
+    public QnaEntity create(QnaRequestDTO requestDTO, List<MultipartFile> images) {
+        String email = throwAuthExceptionOrReturnEmail();
+
+        MemberEntity writer = userService.getUserByEmail(email);
+
+        Qna qna = Qna.builder()
+                .title(requestDTO.getTitle())
+                .content(requestDTO.getTitle())
+                .isPrivate(requestDTO.getIsPrivate())
+                .build();
+        QnaEntity qnaEntity =qnaRepository.save(QnaEntity.toEntity(qna, writer)); // 질문 등록
+        
+        qnaImageService.imageUpload(images, qnaEntity); // 이미지 업로드
+        
+        return qnaEntity;
+    }
+
+
+    // 질문 수정
+    @Override
+    @Transactional
+    public void update(Long qnaId, QnaRequestDTO requestDTO) {
+        String email =throwAuthExceptionOrReturnEmail();
+
+        MemberEntity writer = userService.getUserByEmail(email);
+        QnaEntity qnaEntity = qnaRepository.findById(qnaId);
+
+        // 글쓴 사람과 수정 요청한 사람이 동일한가?
+        if(!qnaEntity.getWriter().getId().equals(writer.getId())){
+            throw new CustomHttpException(HttpErrorCode.UNAUTHORIZED_REQUEST, "질문수정 권한이 없습니다.");
+        }
+        qnaEntity.setTitle(requestDTO.getTitle());
+        qnaEntity.setContent(requestDTO.getContent());
+        qnaEntity.setIsPrivate(requestDTO.getIsPrivate());
+    }
+
+
+    // 질문 삭제
+    @Override
+    @Transactional
+    public void delete(Long id) {
+        String email = throwAuthExceptionOrReturnEmail();
+
+        MemberEntity writer = userService.getUserByEmail(email);
+        QnaEntity qnaEntity = qnaRepository.findById(id);
+
+
+        // 권한 체크
+        if(!qnaEntity.getWriter().getId().equals(writer.getId())){
+            throw new CustomHttpException(HttpErrorCode.UNAUTHORIZED_REQUEST, "질문삭제 권한이 없습니다.");
+        }
+
+//        // TODO: 답변이 달려 있으면 삭제 못하게 막기
+//        if (!qnaEntity.getAnswers().isEmpty()) {
+//            throw new CustomHttpException(HttpErrorCode.CONFLICT, "답변이 있는 질문은 삭제할 수 없습니다.");
+//        }
+
+
+        // 이미지 삭제
+        qnaImageService.imageDelete(qnaImageService.getImages(id), qnaEntity);
+
+        // 질문삭제
+        qnaRepository.deleteById(id);
+    }
+
+    // 질문 상세 조회
+    @Override
+    public QnaDTO getById(Long id) {
+        String email = throwAuthExceptionOrReturnEmail();
+
+        QnaEntity qnaEntity = qnaRepository.findById(id);
+        List<String> imageUrls =qnaImageService.getImages(qnaEntity.getId());
+        return QnaDTO.builder()
+                .id(qnaEntity.getId())
+                .title(qnaEntity.getTitle())
+                .content(qnaEntity.getContent())
+                .isPrivate(qnaEntity.getIsPrivate())
+                .writer(qnaEntity.getWriter().getProfile().getNickname())
+                .isMine(qnaEntity.getWriter().getEmail().equals(email))
+                // TODO: 답변 목록 페이징 처리한 결과들 담아야 함
+                .answers(null)
+                .imageUrls(imageUrls)
+                .createdAt(qnaEntity.getCreatedAt())
+                .build();
+    }
+
+
+    // 질문 목록 조회
+    @Override
+    @Transactional(readOnly = true)
+    public QnaResponseDTO getAllBySearchCondition(QnaSearchConditionDTO conditionDTO, Pageable pageable) {
+        String email = commonUtils.userCheck();
+        return qnaRepository.findAll(conditionDTO,pageable, email);
+    }
+
+
+    // 유저 체크(성공 시 유저 이메일 반환)
+    private String throwAuthExceptionOrReturnEmail(){
+        String email = commonUtils.userCheck();
+        if(email == null){
+            throw new CustomHttpException(HttpErrorCode.UNAUTHORIZED_REQUEST,"로그인 후 이용 가능합니다.");
+        }
+        return email;
+    }
+}

--- a/src/main/java/com/mincho/herb/domain/qna/application/qnaImage/QnaImageService.java
+++ b/src/main/java/com/mincho/herb/domain/qna/application/qnaImage/QnaImageService.java
@@ -1,0 +1,13 @@
+package com.mincho.herb.domain.qna.application.qna;
+
+import com.mincho.herb.domain.qna.application.common.ImageService;
+import com.mincho.herb.domain.qna.entity.QnaEntity;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+public interface QnaImageService extends ImageService {
+
+    void imageUpload(List<MultipartFile> images, QnaEntity qnaEntity);
+    void imageDelete(List<String> images, QnaEntity qnaEntity);
+}

--- a/src/main/java/com/mincho/herb/domain/qna/application/qnaImage/QnaImageServiceImpl.java
+++ b/src/main/java/com/mincho/herb/domain/qna/application/qnaImage/QnaImageServiceImpl.java
@@ -1,0 +1,148 @@
+package com.mincho.herb.domain.qna.application.qna;
+
+import com.mincho.herb.domain.qna.entity.QnaEntity;
+import com.mincho.herb.domain.qna.entity.QnaImageEntity;
+import com.mincho.herb.domain.qna.repository.qnaImage.QnaImageRepository;
+import com.mincho.herb.domain.qna.repository.qna.QnaRepository;
+import com.mincho.herb.global.config.error.HttpErrorCode;
+import com.mincho.herb.global.exception.CustomHttpException;
+import com.mincho.herb.global.util.CommonUtils;
+import com.mincho.herb.infra.auth.S3Service;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class QnaImageServiceImpl implements  QnaImageService {
+
+    private final S3Service s3Service;
+    private final QnaImageRepository qnaImageRepository;
+    private final QnaRepository qnaRepository;
+    private final CommonUtils commonUtils;
+    private static final int MAX_IMAGE_COUNT = 3;
+    private static final long MAX_FILE_SIZE = 1024 * 1024; // 1MB
+    private static final List<String> ALLOWED_EXTENSIONS = List.of(
+            "jpg", "jpeg", "png", "webp", "svg"
+    );
+
+    // 이미지 조회
+    @Override
+    public List<String> getImages(Long qnaId) {
+        return qnaImageRepository.findAllImageUrlsByQnaId(qnaId);
+    }
+
+    // 이미지 업로드
+    @Override
+    public void imageUpload(List<MultipartFile> images, QnaEntity qnaEntity) {
+
+        throwValidImageException(images);
+
+        // 이미지 업로드(S3, DB)
+        images.forEach(image -> {
+            qnaImageRepository.save(
+                    QnaImageEntity.builder()
+                            .imageUrl(s3Service.upload(image, "qna/" + qnaEntity.getId()))
+                            .qna(qnaEntity)
+                            .build()
+            );
+        });
+    }
+
+
+    // 이미지 업로드(API 전용)
+    @Override
+    @Transactional
+    public void imageUpload(List<MultipartFile> images, Long qnaId) {
+            throwValidImageException(images);
+
+            QnaEntity qnaEntity = qnaRepository.findById(qnaId);
+
+            // 이미지 업로드(S3, DB)
+            images.forEach(image -> {
+            qnaImageRepository.save(
+                    QnaImageEntity.builder()
+                            .imageUrl(s3Service.upload(image, "qna/" + qnaEntity.getId()))
+                            .qna(qnaEntity)
+                            .build()
+            );
+        });
+    }
+
+    // 이미지 수정
+    @Override
+    @Transactional
+    public void imageUpdate(List<String> newImageUrls, Long id) {
+        throwAuthExceptionOrReturnEmail(); // 예외 처리
+        
+        List<String> prevImageUrls = qnaImageRepository.findAllImageUrlsByQnaId(id); // 이전 이미지
+
+        // ex [ 1, 2, 3, 4] - [3, 4] = [1, 2] -> prevImageUrls 에는 제거해야 할 이미지만 남는다.
+        prevImageUrls.removeAll(newImageUrls);
+
+        // 빈 게 아니라면 DB, S3 버킷에 반영
+        if (!prevImageUrls.isEmpty()) {
+            qnaImageRepository.deleteByImageUrlIn(prevImageUrls);
+            
+            prevImageUrls.forEach(targetUrl-> {
+                String key = s3Service.extractKeyFromUrl(targetUrl);
+                s3Service.deleteKey(key);
+            });
+        }
+    }
+
+
+    // 이미지 삭제
+    @Override
+    @Transactional
+    public void imageDelete(List<String> imageUrls, QnaEntity qnaEntity) {
+        for(String imageUrl : imageUrls){
+            String key = s3Service.extractKeyFromUrl(imageUrl);
+            s3Service.deleteKey(key);
+        }
+
+        qnaImageRepository.deleteByQnaId(qnaEntity.getId());
+
+    }
+
+
+    // 유저 체크(성공 시 유저 이메일 반환)
+    private String throwAuthExceptionOrReturnEmail(){
+        String email = commonUtils.userCheck();
+        if(email == null){
+            throw new CustomHttpException(HttpErrorCode.UNAUTHORIZED_REQUEST,"로그인 후 이용 가능합니다.");
+        }
+        return email;
+    }
+    
+    // 이미지 유효성 체크
+    private void throwValidImageException(List<MultipartFile> images){
+        if(!images.isEmpty()){
+            if (images.size() > MAX_IMAGE_COUNT) {
+                throw new CustomHttpException(HttpErrorCode.BAD_REQUEST, "이미지는 최대 3개까지만 업로드할 수 있습니다.");
+            }
+
+
+            for (MultipartFile image : images) {
+                if (image.isEmpty()) {
+                    throw new CustomHttpException(HttpErrorCode.BAD_REQUEST,"빈 파일은 업로드할 수 없습니다.");
+                }
+
+                if (image.getSize() > MAX_FILE_SIZE) {
+                    throw new CustomHttpException(HttpErrorCode.BAD_REQUEST,"각 이미지 파일 크기는 1MB 이하여야 합니다.");
+                }
+
+                log.info("image type:{}", image.getContentType());
+                if (!ALLOWED_EXTENSIONS.contains(Objects.requireNonNull(image.getContentType()).split("/")[1])) {
+                    throw new CustomHttpException(HttpErrorCode.BAD_REQUEST,"지원하지 않는 이미지 형식입니다. (JPEG, PNG, webp, svg 만 허용)");
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/mincho/herb/domain/qna/domain/Answer.java
+++ b/src/main/java/com/mincho/herb/domain/qna/domain/Answer.java
@@ -1,0 +1,4 @@
+package com.mincho.herb.domain.qna.domain;
+
+public class Answer {
+}

--- a/src/main/java/com/mincho/herb/domain/qna/domain/AnswerImage.java
+++ b/src/main/java/com/mincho/herb/domain/qna/domain/AnswerImage.java
@@ -1,0 +1,11 @@
+package com.mincho.herb.domain.qna.domain;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class QnaImage {
+    private Long id;
+    private String imageUrl;
+}

--- a/src/main/java/com/mincho/herb/domain/qna/domain/Qna.java
+++ b/src/main/java/com/mincho/herb/domain/qna/domain/Qna.java
@@ -1,0 +1,4 @@
+package com.mincho.herb.domain.qna.domain;
+
+public class Qna {
+}

--- a/src/main/java/com/mincho/herb/domain/qna/domain/QnaImage.java
+++ b/src/main/java/com/mincho/herb/domain/qna/domain/QnaImage.java
@@ -1,0 +1,4 @@
+package com.mincho.herb.domain.qna.domain;
+
+public class QnaImage {
+}

--- a/src/main/java/com/mincho/herb/domain/qna/dto/AnswerRequestDTO.java
+++ b/src/main/java/com/mincho/herb/domain/qna/dto/AnswerRequestDTO.java
@@ -1,0 +1,4 @@
+package com.mincho.herb.domain.qna.dto;
+
+public class AnswerRequestDTO {
+}

--- a/src/main/java/com/mincho/herb/domain/qna/dto/AnswerSummaryDTO.java
+++ b/src/main/java/com/mincho/herb/domain/qna/dto/AnswerSummaryDTO.java
@@ -1,0 +1,4 @@
+package com.mincho.herb.domain.qna.dto;
+
+public class AnswerSummaryDTO {
+}

--- a/src/main/java/com/mincho/herb/domain/qna/dto/QnaImageResponseDTO.java
+++ b/src/main/java/com/mincho/herb/domain/qna/dto/QnaImageResponseDTO.java
@@ -1,0 +1,4 @@
+package com.mincho.herb.domain.qna.dto;
+
+public class QnaImageResponseDTO {
+}

--- a/src/main/java/com/mincho/herb/domain/qna/dto/QnaRequestDTO.java
+++ b/src/main/java/com/mincho/herb/domain/qna/dto/QnaRequestDTO.java
@@ -1,0 +1,4 @@
+package com.mincho.herb.domain.qna.dto;
+
+public class QnaRequestDTO {
+}

--- a/src/main/java/com/mincho/herb/domain/qna/dto/QnaResponseDTO.java
+++ b/src/main/java/com/mincho/herb/domain/qna/dto/QnaResponseDTO.java
@@ -1,0 +1,4 @@
+package com.mincho.herb.domain.qna.dto;
+
+public class QnaResponseDTO {
+}

--- a/src/main/java/com/mincho/herb/domain/qna/dto/QnaSearchConditionDTO.java
+++ b/src/main/java/com/mincho/herb/domain/qna/dto/QnaSearchConditionDTO.java
@@ -1,0 +1,4 @@
+package com.mincho.herb.domain.qna.dto;
+
+public class QnaSearchConditionDTO {
+}

--- a/src/main/java/com/mincho/herb/domain/qna/dto/QnaSummaryDTO.java
+++ b/src/main/java/com/mincho/herb/domain/qna/dto/QnaSummaryDTO.java
@@ -1,0 +1,4 @@
+package com.mincho.herb.domain.qna.dto;
+
+public class QnaSummaryDTO {
+}

--- a/src/main/java/com/mincho/herb/domain/qna/entity/AnswerImageEntity.java
+++ b/src/main/java/com/mincho/herb/domain/qna/entity/AnswerImageEntity.java
@@ -1,0 +1,4 @@
+package com.mincho.herb.domain.qna.entity;
+
+public class AnswerImageEntity {
+}

--- a/src/main/java/com/mincho/herb/domain/qna/entity/QnaImageEntity.java
+++ b/src/main/java/com/mincho/herb/domain/qna/entity/QnaImageEntity.java
@@ -1,0 +1,4 @@
+package com.mincho.herb.domain.qna.entity;
+
+public class QnaImages {
+}

--- a/src/main/java/com/mincho/herb/domain/qna/entity/QnaReactionEntity.java
+++ b/src/main/java/com/mincho/herb/domain/qna/entity/QnaReactionEntity.java
@@ -1,0 +1,4 @@
+package com.mincho.herb.domain.qna.entity;
+
+public class QnaReactionEntity {
+}

--- a/src/main/java/com/mincho/herb/domain/qna/entity/QnaReactionType.java
+++ b/src/main/java/com/mincho/herb/domain/qna/entity/QnaReactionType.java
@@ -1,0 +1,4 @@
+package com.mincho.herb.domain.qna.entity;
+
+public class QnaReactionType {
+}

--- a/src/main/java/com/mincho/herb/domain/qna/repository/answer/AnswerJpaRepository.java
+++ b/src/main/java/com/mincho/herb/domain/qna/repository/answer/AnswerJpaRepository.java
@@ -1,0 +1,4 @@
+package com.mincho.herb.domain.qna.repository.answer;
+
+public interface AnswerJpaRepository {
+}

--- a/src/main/java/com/mincho/herb/domain/qna/repository/answer/AnswerRepository.java
+++ b/src/main/java/com/mincho/herb/domain/qna/repository/answer/AnswerRepository.java
@@ -1,0 +1,7 @@
+package com.mincho.herb.domain.qna.repository.answer;
+
+import com.mincho.herb.domain.qna.entity.AnswerEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AnswerJpaRepository extends JpaRepository<AnswerEntity, Long> {
+}

--- a/src/main/java/com/mincho/herb/domain/qna/repository/answer/AnswerRepositoryImpl.java
+++ b/src/main/java/com/mincho/herb/domain/qna/repository/answer/AnswerRepositoryImpl.java
@@ -1,0 +1,7 @@
+package com.mincho.herb.domain.qna.repository.answer;
+
+import com.mincho.herb.domain.qna.entity.AnswerEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AnswerRepository extends JpaRepository<AnswerEntity, Long> {
+}

--- a/src/main/java/com/mincho/herb/domain/qna/repository/answerImage/AnswerImageJpaRepository.java
+++ b/src/main/java/com/mincho/herb/domain/qna/repository/answerImage/AnswerImageJpaRepository.java
@@ -1,0 +1,4 @@
+package com.mincho.herb.domain.qna.repository.answerImage;
+
+public interface AnswerImageJpaRepository {
+}

--- a/src/main/java/com/mincho/herb/domain/qna/repository/answerImage/AnswerImageRepository.java
+++ b/src/main/java/com/mincho/herb/domain/qna/repository/answerImage/AnswerImageRepository.java
@@ -1,0 +1,4 @@
+package com.mincho.herb.domain.qna.repository.answerImage;
+
+public interface AnswerImageRepository {
+}

--- a/src/main/java/com/mincho/herb/domain/qna/repository/answerImage/AnswerImageRepositoryImpl.java
+++ b/src/main/java/com/mincho/herb/domain/qna/repository/answerImage/AnswerImageRepositoryImpl.java
@@ -1,0 +1,8 @@
+package com.mincho.herb.domain.qna.repository.answerImage;
+
+import com.mincho.herb.domain.qna.entity.AnswerImageEntity;
+
+public interface AnswerImageRepository {
+
+    AnswerImageEntity save();
+}

--- a/src/main/java/com/mincho/herb/domain/qna/repository/qna/QnaJpaRepository.java
+++ b/src/main/java/com/mincho/herb/domain/qna/repository/qna/QnaJpaRepository.java
@@ -1,0 +1,7 @@
+package com.mincho.herb.domain.qna.repository.answer;
+
+import com.mincho.herb.domain.qna.entity.AnswerEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AnswerJpaRepository extends JpaRepository<AnswerEntity, Long> {
+}

--- a/src/main/java/com/mincho/herb/domain/qna/repository/qna/QnaRepository.java
+++ b/src/main/java/com/mincho/herb/domain/qna/repository/qna/QnaRepository.java
@@ -1,0 +1,7 @@
+package com.mincho.herb.domain.qna.repository.qna;
+
+import com.mincho.herb.domain.qna.entity.QnaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QnaJpaRepository extends JpaRepository<QnaEntity, Long> {
+}

--- a/src/main/java/com/mincho/herb/domain/qna/repository/qna/QnaRepositoryImpl.java
+++ b/src/main/java/com/mincho/herb/domain/qna/repository/qna/QnaRepositoryImpl.java
@@ -1,0 +1,4 @@
+package com.mincho.herb.domain.qna.repository.qna;
+
+public interface QnaRepository{
+}

--- a/src/main/java/com/mincho/herb/domain/qna/repository/qnaImage/QnaImageJpaRepository.java
+++ b/src/main/java/com/mincho/herb/domain/qna/repository/qnaImage/QnaImageJpaRepository.java
@@ -1,0 +1,4 @@
+package com.mincho.herb.domain.qna.repository.QnaImage;
+
+public interface QnaImagJpaRepository {
+}

--- a/src/main/java/com/mincho/herb/domain/qna/repository/qnaImage/QnaImageRepository.java
+++ b/src/main/java/com/mincho/herb/domain/qna/repository/qnaImage/QnaImageRepository.java
@@ -1,0 +1,4 @@
+package com.mincho.herb.domain.qna.repository.QnaImage;
+
+public interface QnaImageJpaRepository {
+}

--- a/src/main/java/com/mincho/herb/domain/qna/repository/qnaImage/QnaImageRepositoryImpl.java
+++ b/src/main/java/com/mincho/herb/domain/qna/repository/qnaImage/QnaImageRepositoryImpl.java
@@ -1,0 +1,4 @@
+package com.mincho.herb.domain.qna.repository.QnaImage;
+
+public interface QnaImageRepository {
+}


### PR DESCRIPTION
## 📌 PR 제목  
- QnA 이미지 업로드/조회/수정/삭제 기능 구현, answer 답변 등록 기능 구현 및  유효성 검증 로직 추가

## ✨ 변경 사항  
- QnA 게시글에 이미지 업로드 기능 구현 (S3 업로드 및 DB 저장)
- 이미지 유효성 검사 로직 추가 (최대 3개, 파일 크기 1MB 이하, 형식 제한)
- 이미지 수정 시 기존 이미지 비교 후 삭제 처리
- QnA 삭제 시 이미 등록된 답변이 있으면 삭제 안 되도록 처리
- QnA 삭제 시 S3 버킷, 디비 모두에서 이미지 삭제되도록 처리
- QnA ID 기반 이미지 조회 및 삭제 기능 구현
- 공통 유저 인증 예외 처리 메서드 추가
- 주요 메서드에 상세 JavaDoc 주석 작성
- 질문에 대한 answer 답변 등록 기능 추가

## 🔍 테스트 방법  
- Postman 을 사용하여 정상동작 테스트

## ❗ 주의 사항  
- answer 답변 수정, 삭제 미구현

## ✅ 관련 이슈  
- 없음
